### PR TITLE
Adds inactive_user to the email context for the

### DIFF
--- a/verify_email/email_handler.py
+++ b/verify_email/email_handler.py
@@ -45,7 +45,7 @@ class _VerifyEmail:
 
             verification_url = self.token_manager.generate_link(request, inactive_user, useremail)
             msg = render_to_string(self.settings.get('html_message_template', raise_exception=True),
-                                   {"link": verification_url}, request=request)
+                                   {"link": verification_url, "inactive_user": inactive_user}, request=request)
 
             if self.__send_email(msg, useremail):
                 return inactive_user


### PR DESCRIPTION
initial verification email.

This way we can include personalised information such as, Hello John Smith, please verify your email for the account with username: username