### PR TITLE
Use Http404 instead of HttpResponse

### DIFF
--- a/verify_email/views.py
+++ b/verify_email/views.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponse
+from django.http import Http404, HttpResponse
 from .app_configurations import GetFieldFromSettings
 from .confirm import verify_user
 from django.urls import reverse
@@ -108,7 +108,7 @@ def verify_user_and_activate(request, useremail, usertoken):
             }
         )
     except UserNotFound:
-        return HttpResponse("404 User not found", status=404)
+        raise Http404("404 User not found")
 
 
 def request_new_link(request, user_email=None, user_token=None):


### PR DESCRIPTION
Using `Http404` allows for Django to catch the 404 and serve the default 404 page instead. This way, when running a production site, you can have your own 404 template instead of the plain string.

I guess this is pretty much the only acceptable way in Django.

Background read: https://docs.djangoproject.com/en/3.2/topics/http/views/#the-http404-exception

Thank you for your efforts on this project!