### PR TITLE
Use Python's logging framework instead of print

### DIFF
--- a/verify_email/apps.py
+++ b/verify_email/apps.py
@@ -1,9 +1,11 @@
+import logging
 from django.apps import AppConfig
 
+logger = logging.getLogger(__name__)
 
 class VerifyEmailConfig(AppConfig):
     name = 'verify_email'
 
     def ready(self):
-        print('[Email Verification] : importing signals    - OK.')
+        logger.info('[Email Verification] : importing signals    - OK.')
         import verify_email.signals

--- a/verify_email/signals.py
+++ b/verify_email/signals.py
@@ -1,7 +1,9 @@
+import logging
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from .models import LinkCounter, USER
 
+logger = logging.getLogger(__name__)
 
 @receiver(post_save, sender=USER)
 def increase_count(sender, instance, created, **kwargs):
@@ -14,4 +16,4 @@ def save_count(sender, instance, **kwargs):
     try:
         instance.linkcounter.save()
     except Exception as err:
-        print(err)
+        logger.error(err)

--- a/verify_email/token_manager.py
+++ b/verify_email/token_manager.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import timedelta
 from django.core import signing
 from binascii import Error as BASE64ERROR
@@ -12,6 +13,7 @@ __all__ = [
     "TokenManager"
 ]
 
+logger = logging.getLogger(__name__)
 
 class TokenManager(signing.TimestampSigner):
     """
@@ -98,7 +100,7 @@ class TokenManager(signing.TimestampSigner):
         try:
             return int(user.linkcounter.sent_count)
         except Exception as e:
-            print(e)
+            logger.error(e)
             return False
 
     @staticmethod
@@ -217,18 +219,18 @@ class TokenManager(signing.TimestampSigner):
                     return False
 
                 except signing.SignatureExpired:
-                    print(f'\n{"~" * 40}\n[ERROR] : The link is Expired!\n{"~" * 40}\n')
+                    logger.warning(f'\n{"~" * 40}\n[WARNING] : The link is Expired!\n{"~" * 40}\n')
                     user = self.get_user_by_token(decoded_email, self.__decrypt_expired_user(decoded_token))
                     if not self.__verify_attempts(user):
                         raise MaxRetriesExceeded()
                     raise
 
                 except signing.BadSignature:
-                    print(f'\n{"~" * 40}\n[CRITICAL] : X_x --> CAUTION : LINK SIGNATURE ALTERED! <-- x_X\n{"~" * 40}\n')
+                    logger.critical(f'\n{"~" * 40}\n[CRITICAL] : X_x --> CAUTION : LINK SIGNATURE ALTERED! <-- x_X\n{"~" * 40}\n')
                     raise
             else:
                 user = self.get_user_by_token(decoded_email, decoded_token)
                 return user if user else False
         else:
-            print(f'\n{"~" * 40}\n[ERROR] : Error occurred in decoding the link!\n{"~" * 40}\n')
+            logger.error(f'\n{"~" * 40}\n[ERROR] : Error occurred in decoding the link!\n{"~" * 40}\n')
             return False

--- a/verify_email/views.py
+++ b/verify_email/views.py
@@ -1,3 +1,4 @@
+import logging
 from django.http import HttpResponse
 from .app_configurations import GetFieldFromSettings
 from .confirm import verify_user
@@ -16,6 +17,8 @@ from .errors import (
     UserAlreadyActive,
     UserNotFound,
 )
+
+logger = logging.getLogger(__name__)
 
 pkg_configs = GetFieldFromSettings()
 
@@ -58,7 +61,7 @@ def verify_user_and_activate(request, useremail, usertoken):
             # we dont know what went wrong...
             raise ValueError
     except (ValueError, TypeError) as error:
-        print(f'[ERROR]: Something went wrong while verifying user, exception: {error}')
+        logger.error(f'[ERROR]: Something went wrong while verifying user, exception: {error}')
         return render(
             request,
             template_name=failed_template,
@@ -138,7 +141,7 @@ def request_new_link(request, user_email=None, user_token=None):
                                 }
                             )
                         else:
-                            print('something went wrong during sending email')
+                            logger.error('something went wrong during sending email')
             else:
                 form = RequestNewVerificationEmail()
             return render(
@@ -162,23 +165,23 @@ def request_new_link(request, user_email=None, user_token=None):
             )
         else:
             messages.info(request, 'Something went wrong during sending email :(')
-            print('something went wrong during sending email')
+            logger.error('something went wrong during sending email')
 
     except ObjectDoesNotExist as error:
         messages.warning(request, 'User not found associated with given email!')
-        print(f'[ERROR]: User not found. exception: {error}')
+        logger.error(f'[ERROR]: User not found. exception: {error}')
         return HttpResponse(b"User Not Found", status=404)
 
     except MultipleObjectsReturned as error:
-        print(f'[ERROR]: Multiple users found. exception: {error}')
+        logger.error(f'[ERROR]: Multiple users found. exception: {error}')
         return HttpResponse(b"Internal server error!", status=500)
 
     except KeyError as error:
-        print(f'[ERROR]: Key error for email in your form: {error}')
+        logger.error(f'[ERROR]: Key error for email in your form: {error}')
         return HttpResponse(b"Internal server error!", status=500)
 
     except MaxRetriesExceeded as error:
-        print(f'[ERROR]: Maximum retries for link has been reached. exception: {error}')
+        logger.error(f'[ERROR]: Maximum retries for link has been reached. exception: {error}')
         return render(
             request,
             template_name=failed_template,


### PR DESCRIPTION
Using `print()` statements does not allow us to control logging in production environments. This PR replaces all calls to `print` with a corresponding call to the logging framework.

After merging this PR, with your blessing, I'll create another PR that removes the `~` and line breaks as well as the `[ERROR]` statements from the log messages. The logging framework will take care of that.


Background read: https://docs.djangoproject.com/en/4.0/howto/logging/#logging-how-to
