### PR TITLE
Add workaround for Microsoft outlook protections links

### DIFF
--- a/verify_email/email_handler.py
+++ b/verify_email/email_handler.py
@@ -28,13 +28,17 @@ class _VerifyEmail:
         )
 
     # Public :
-    def send_verification_link(self, request, form):
-        inactive_user = form.save(commit=False)
+    def send_verification_link(self, request, inactive_user=None, form=None):
+        
+        if form:
+            inactive_user = form.save(commit=False)
+        
         inactive_user.is_active = False
         inactive_user.save()
 
         try:
-            useremail = form.cleaned_data.get(self.settings.get('email_field_name'))
+            
+            useremail = form.cleaned_data.get(self.settings.get('email_field_name')) if form else inactive_user.email
             if not useremail:
                 raise KeyError(
                     'No key named "email" in your form. Your field should be named as email in form OR set a variable'

--- a/verify_email/email_handler.py
+++ b/verify_email/email_handler.py
@@ -28,17 +28,13 @@ class _VerifyEmail:
         )
 
     # Public :
-    def send_verification_link(self, request, inactive_user=None, form=None):
-        
-        if form:
-            inactive_user = form.save(commit=False)
-        
+    def send_verification_link(self, request, form):
+        inactive_user = form.save(commit=False)
         inactive_user.is_active = False
         inactive_user.save()
 
         try:
-            
-            useremail = form.cleaned_data.get(self.settings.get('email_field_name')) if form else inactive_user.email
+            useremail = form.cleaned_data.get(self.settings.get('email_field_name'))
             if not useremail:
                 raise KeyError(
                     'No key named "email" in your form. Your field should be named as email in form OR set a variable'

--- a/verify_email/views.py
+++ b/verify_email/views.py
@@ -42,77 +42,77 @@ def verify_user_and_activate(request, useremail, usertoken):
 
     verify the user's email and token and redirect'em accordingly.
     """
-
-    try:
-        verified = verify_user(useremail, usertoken)
-        if verified is True:
-            if login_page and not success_template:
-                messages.success(request, success_msg)
-                return redirect(to=login_page)
+    if request.method == 'GET':
+        try:
+            verified = verify_user(useremail, usertoken)
+            if verified is True:
+                if login_page and not success_template:
+                    messages.success(request, success_msg)
+                    return redirect(to=login_page)
+                return render(
+                    request,
+                    template_name=success_template,
+                    context={
+                        'msg': success_msg,
+                        'status': 'Verification Successful!',
+                        'link': reverse(login_page)
+                    }
+                )
+            else:
+                # we dont know what went wrong...
+                raise ValueError
+        except (ValueError, TypeError) as error:
+            logger.error(f'[ERROR]: Something went wrong while verifying user, exception: {error}')
             return render(
                 request,
-                template_name=success_template,
+                template_name=failed_template,
                 context={
-                    'msg': success_msg,
-                    'status': 'Verification Successful!',
-                    'link': reverse(login_page)
+                    'msg': failed_msg,
+                    'minor_msg': 'There is something wrong with this link...',
+                    'status': 'Verification Failed!',
                 }
             )
-        else:
-            # we dont know what went wrong...
-            raise ValueError
-    except (ValueError, TypeError) as error:
-        logger.error(f'[ERROR]: Something went wrong while verifying user, exception: {error}')
-        return render(
-            request,
-            template_name=failed_template,
-            context={
-                'msg': failed_msg,
-                'minor_msg': 'There is something wrong with this link...',
-                'status': 'Verification Failed!',
-            }
-        )
-    except SignatureExpired:
-        return render(
-            request,
-            template_name=link_expired_template,
-            context={
-                'msg': 'The link has lived its life :( Request a new one!',
-                'status': 'Expired!',
-                'encoded_email': useremail,
-                'encoded_token': usertoken
-            }
-        )
-    except BadSignature:
-        return render(
-            request,
-            template_name=failed_template,
-            context={
-                'msg': 'This link was modified before verification.',
-                'minor_msg': 'Cannot request another verification link with faulty link.',
-                'status': 'Faulty Link Detected!',
-            }
-        )
-    except MaxRetriesExceeded:
-        return render(
-            request,
-            template_name=failed_template,
-            context={
-                'msg': 'You have exceeded the maximum verification requests! Contact admin.',
-                'status': 'Maxed out!',
-            }
-        )
-    except InvalidToken:
-        return render(
-            request,
-            template_name=failed_template,
-            context={
-                'msg': 'This link is invalid or been used already, we cannot verify using this link.',
-                'status': 'Invalid Link',
-            }
-        )
-    except UserNotFound:
-        raise Http404("404 User not found")
+        except SignatureExpired:
+            return render(
+                request,
+                template_name=link_expired_template,
+                context={
+                    'msg': 'The link has lived its life :( Request a new one!',
+                    'status': 'Expired!',
+                    'encoded_email': useremail,
+                    'encoded_token': usertoken
+                }
+            )
+        except BadSignature:
+            return render(
+                request,
+                template_name=failed_template,
+                context={
+                    'msg': 'This link was modified before verification.',
+                    'minor_msg': 'Cannot request another verification link with faulty link.',
+                    'status': 'Faulty Link Detected!',
+                }
+            )
+        except MaxRetriesExceeded:
+            return render(
+                request,
+                template_name=failed_template,
+                context={
+                    'msg': 'You have exceeded the maximum verification requests! Contact admin.',
+                    'status': 'Maxed out!',
+                }
+            )
+        except InvalidToken:
+            return render(
+                request,
+                template_name=failed_template,
+                context={
+                    'msg': 'This link is invalid or been used already, we cannot verify using this link.',
+                    'status': 'Invalid Link',
+                }
+            )
+        except UserNotFound:
+            raise Http404("404 User not found")
 
 
 def request_new_link(request, useremail=None, usertoken=None):


### PR DESCRIPTION
In Microsoft outlook/Office365 the safe links protection makes a `HEAD` request to the page to make sure it's safe before redirecting the user. This always results in an invalid link message as the link has already been used. 

Adding a ` if request.method == 'GET': ` to the link checking means that the link is still valid when the user is redirected. 