### PR TITLE
More changes for Microsoft Safe link protection

### DIFF
--- a/verify_email/app_configurations.py
+++ b/verify_email/app_configurations.py
@@ -84,6 +84,12 @@ class GetFieldFromSettings:
                 'verify_email/new_email_sent.html'
             ),
 
+            'verification_template': (
+                'NEW_EMAIL_SENT_TEMPLATE',
+                'verify_email/verification_template.html'
+            ),
+
+
             'salt': (
                 'HASH_SALT',
                 None

--- a/verify_email/app_configurations.py
+++ b/verify_email/app_configurations.py
@@ -85,7 +85,7 @@ class GetFieldFromSettings:
             ),
 
             'verification_template': (
-                'NEW_EMAIL_SENT_TEMPLATE',
+                'VERIFICATION_TEMPLATE',
                 'verify_email/verification_template.html'
             ),
 

--- a/verify_email/email_handler.py
+++ b/verify_email/email_handler.py
@@ -28,7 +28,7 @@ class _VerifyEmail:
         )
 
     # Public :
-    def send_verification_link(self, request, inactive_user=None, form=None):
+    def send_verification_link(self, request, form=None):
         
         if form:
             inactive_user = form.save(commit=False)

--- a/verify_email/templates/verify_email/verification_template.html
+++ b/verify_email/templates/verify_email/verification_template.html
@@ -1,0 +1,33 @@
+{% extends "email_index.html" %}
+
+{%block content%}
+
+<div class="container" 
+    style="
+    height: auto;
+    margin-bottom: 0px; 
+    margin-top: 100px;
+    padding: 100px; 
+    border: 0px solid red;
+    background-color: rgb(255, 255, 255);
+    border-radius: 20px;
+    box-shadow: rgba(17, 12, 46, 0.15) 0px 48px 100px 0px;
+    
+    ">
+    <div class="container mt-5">
+        <h2 style="margin-bottom: 20px;">Click the button below to verify your email address</h2>
+        <hr>
+    <form method="POST">
+        {% csrf_token %}
+    <div style="margin-top: 50px;">
+        <button class="btn btn-outline-success" type="submit">Verify Email</button>
+    </div>
+    </form>
+    
+        <div class="border-top pt-3 mt-3">
+            <small>Usually this template needs to be changed by your own app's template</small>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/verify_email/views.py
+++ b/verify_email/views.py
@@ -33,7 +33,7 @@ success_template = pkg_configs.get('verification_success_template')
 link_expired_template = pkg_configs.get('link_expired_template')
 request_new_email_template = pkg_configs.get('request_new_email_template')
 new_email_sent_template = pkg_configs.get('new_email_sent_template')
-
+verify_template = pkg_configs.get('verification_template')
 
 def verify_user_and_activate(request, useremail, usertoken):
     """
@@ -42,78 +42,84 @@ def verify_user_and_activate(request, useremail, usertoken):
 
     verify the user's email and token and redirect'em accordingly.
     """
-    if request.method == 'GET':
-        try:
-            verified = verify_user(useremail, usertoken)
-            if verified is True:
-                if login_page and not success_template:
-                    messages.success(request, success_msg)
-                    return redirect(to=login_page)
+    def verify_button_clicked(request, useremail, usertoken):
+        if request.method == 'GET':
+            try:
+                verified = verify_user(useremail, usertoken)
+                if verified is True:
+                    if login_page and not success_template:
+                        messages.success(request, success_msg)
+                        return redirect(to=login_page)
+                    return render(
+                        request,
+                        template_name=success_template,
+                        context={
+                            'msg': success_msg,
+                            'status': 'Verification Successful!',
+                            'link': reverse(login_page)
+                        }
+                    )
+                else:
+                    # we dont know what went wrong...
+                    raise ValueError
+            except (ValueError, TypeError) as error:
+                logger.error(f'[ERROR]: Something went wrong while verifying user, exception: {error}')
                 return render(
                     request,
-                    template_name=success_template,
+                    template_name=failed_template,
                     context={
-                        'msg': success_msg,
-                        'status': 'Verification Successful!',
-                        'link': reverse(login_page)
+                        'msg': failed_msg,
+                        'minor_msg': 'There is something wrong with this link...',
+                        'status': 'Verification Failed!',
                     }
                 )
-            else:
-                # we dont know what went wrong...
-                raise ValueError
-        except (ValueError, TypeError) as error:
-            logger.error(f'[ERROR]: Something went wrong while verifying user, exception: {error}')
-            return render(
-                request,
-                template_name=failed_template,
-                context={
-                    'msg': failed_msg,
-                    'minor_msg': 'There is something wrong with this link...',
-                    'status': 'Verification Failed!',
-                }
-            )
-        except SignatureExpired:
-            return render(
-                request,
-                template_name=link_expired_template,
-                context={
-                    'msg': 'The link has lived its life :( Request a new one!',
-                    'status': 'Expired!',
-                    'encoded_email': useremail,
-                    'encoded_token': usertoken
-                }
-            )
-        except BadSignature:
-            return render(
-                request,
-                template_name=failed_template,
-                context={
-                    'msg': 'This link was modified before verification.',
-                    'minor_msg': 'Cannot request another verification link with faulty link.',
-                    'status': 'Faulty Link Detected!',
-                }
-            )
-        except MaxRetriesExceeded:
-            return render(
-                request,
-                template_name=failed_template,
-                context={
-                    'msg': 'You have exceeded the maximum verification requests! Contact admin.',
-                    'status': 'Maxed out!',
-                }
-            )
-        except InvalidToken:
-            return render(
-                request,
-                template_name=failed_template,
-                context={
-                    'msg': 'This link is invalid or been used already, we cannot verify using this link.',
-                    'status': 'Invalid Link',
-                }
-            )
-        except UserNotFound:
-            raise Http404("404 User not found")
-
+            except SignatureExpired:
+                return render(
+                    request,
+                    template_name=link_expired_template,
+                    context={
+                        'msg': 'The link has lived its life :( Request a new one!',
+                        'status': 'Expired!',
+                        'encoded_email': useremail,
+                        'encoded_token': usertoken
+                    }
+                )
+            except BadSignature:
+                return render(
+                    request,
+                    template_name=failed_template,
+                    context={
+                        'msg': 'This link was modified before verification.',
+                        'minor_msg': 'Cannot request another verification link with faulty link.',
+                        'status': 'Faulty Link Detected!',
+                    }
+                )
+            except MaxRetriesExceeded:
+                return render(
+                    request,
+                    template_name=failed_template,
+                    context={
+                        'msg': 'You have exceeded the maximum verification requests! Contact admin.',
+                        'status': 'Maxed out!',
+                    }
+                )
+            except InvalidToken:
+                return render(
+                    request,
+                    template_name=failed_template,
+                    context={
+                        'msg': 'This link is invalid or been used already, we cannot verify using this link.',
+                        'status': 'Invalid Link',
+                    }
+                )
+            except UserNotFound:
+                raise Http404("404 User not found")
+    if request.method == 'POST':
+        form = request.POST
+        if form.is_valid():
+            verify_button_clicked(request, useremail, usertoken)
+    else:
+        return render(request, template_name=verify_template)
 
 def request_new_link(request, useremail=None, usertoken=None):
     try:

--- a/verify_email/views.py
+++ b/verify_email/views.py
@@ -115,9 +115,7 @@ def verify_user_and_activate(request, useremail, usertoken):
             except UserNotFound:
                 raise Http404("404 User not found")
     if request.method == 'POST':
-        form = request.POST
-        if form.is_valid():
-            verify_button_clicked(request, useremail, usertoken)
+        verify_button_clicked(request, useremail, usertoken)
     else:
         return render(request, template_name=verify_template)
 

--- a/verify_email/views.py
+++ b/verify_email/views.py
@@ -42,83 +42,80 @@ def verify_user_and_activate(request, useremail, usertoken):
 
     verify the user's email and token and redirect'em accordingly.
     """
-    def verify_button_clicked(request, useremail, usertoken):
-        if request.method == 'GET':
-            try:
-                verified = verify_user(useremail, usertoken)
-                if verified is True:
-                    if login_page and not success_template:
-                        messages.success(request, success_msg)
-                        return redirect(to=login_page)
-                    return render(
-                        request,
-                        template_name=success_template,
-                        context={
-                            'msg': success_msg,
-                            'status': 'Verification Successful!',
-                            'link': reverse(login_page)
-                        }
-                    )
-                else:
-                    # we dont know what went wrong...
-                    raise ValueError
-            except (ValueError, TypeError) as error:
-                logger.error(f'[ERROR]: Something went wrong while verifying user, exception: {error}')
-                return render(
-                    request,
-                    template_name=failed_template,
-                    context={
-                        'msg': failed_msg,
-                        'minor_msg': 'There is something wrong with this link...',
-                        'status': 'Verification Failed!',
-                    }
-                )
-            except SignatureExpired:
-                return render(
-                    request,
-                    template_name=link_expired_template,
-                    context={
-                        'msg': 'The link has lived its life :( Request a new one!',
-                        'status': 'Expired!',
-                        'encoded_email': useremail,
-                        'encoded_token': usertoken
-                    }
-                )
-            except BadSignature:
-                return render(
-                    request,
-                    template_name=failed_template,
-                    context={
-                        'msg': 'This link was modified before verification.',
-                        'minor_msg': 'Cannot request another verification link with faulty link.',
-                        'status': 'Faulty Link Detected!',
-                    }
-                )
-            except MaxRetriesExceeded:
-                return render(
-                    request,
-                    template_name=failed_template,
-                    context={
-                        'msg': 'You have exceeded the maximum verification requests! Contact admin.',
-                        'status': 'Maxed out!',
-                    }
-                )
-            except InvalidToken:
-                return render(
-                    request,
-                    template_name=failed_template,
-                    context={
-                        'msg': 'This link is invalid or been used already, we cannot verify using this link.',
-                        'status': 'Invalid Link',
-                    }
-                )
-            except UserNotFound:
-                raise Http404("404 User not found")
     if request.method == 'POST':
-        verify_button_clicked(request, useremail, usertoken)
+        try:
+            verified = verify_user(useremail, usertoken)
+            if verified is True:
+                if login_page and not success_template:
+                    messages.success(request, success_msg)
+                    return redirect(to=login_page)
+                return render(
+                    request,
+                    template_name=success_template,
+                    context={
+                        'msg': success_msg,
+                        'status': 'Verification Successful!',
+                        'link': reverse(login_page)
+                    }
+                )
+            else:
+                # we dont know what went wrong...
+                raise ValueError
+        except (ValueError, TypeError) as error:
+            logger.error(f'[ERROR]: Something went wrong while verifying user, exception: {error}')
+            return render(
+                request,
+                template_name=failed_template,
+                context={
+                    'msg': failed_msg,
+                    'minor_msg': 'There is something wrong with this link...',
+                    'status': 'Verification Failed!',
+                }
+            )
+        except SignatureExpired:
+            return render(
+                request,
+                template_name=link_expired_template,
+                context={
+                    'msg': 'The link has lived its life :( Request a new one!',
+                    'status': 'Expired!',
+                    'encoded_email': useremail,
+                    'encoded_token': usertoken
+                }
+            )
+        except BadSignature:
+            return render(
+                request,
+                template_name=failed_template,
+                context={
+                    'msg': 'This link was modified before verification.',
+                    'minor_msg': 'Cannot request another verification link with faulty link.',
+                    'status': 'Faulty Link Detected!',
+                }
+            )
+        except MaxRetriesExceeded:
+            return render(
+                request,
+                template_name=failed_template,
+                context={
+                    'msg': 'You have exceeded the maximum verification requests! Contact admin.',
+                    'status': 'Maxed out!',
+                }
+            )
+        except InvalidToken:
+            return render(
+                request,
+                template_name=failed_template,
+                context={
+                    'msg': 'This link is invalid or been used already, we cannot verify using this link.',
+                    'status': 'Invalid Link',
+                }
+            )
+        except UserNotFound:
+            raise Http404("404 User not found")
     else:
         return render(request, template_name=verify_template)
-
+    
 def request_new_link(request, useremail=None, usertoken=None):
     try:
         if useremail is None or usertoken is None:


### PR DESCRIPTION
So, after testing my site internally, the previous fix of just checking for a `HEAD` request was fine. As I was accessing my site with a private IP address. However, after deploying the site, it turns out that Microsoft actually checks the link before it even sends the email. So the link is always invalid when the user finally gets it. 

My solution here is to add a page where the user must click a button for the verification to actually be processed. The pros of this approach is that it doesn't matter what checks Microsoft, or anyone does on the email link, as the user must press the verify button for the verification to proceed. 

The cons are that it adds another step in for the end user and the link in the email remains valid no matter how many times the user click on it, it is only used once they click the verify button. 

I added a template that matches the rest of the templates and can be swapped out with a custom template like all the others. 

This is potentially only an issue when using the `mail.protection.outlook.com` email provider

Also, the verification email would not send without error unless I removed ` inactive_user=None,` from 
```
...

    # Private :
    def __send_email(self, msg, useremail):
        subject = self.settings.get('subject')
        send_mail(
            subject, strip_tags(msg),
            from_email=self.settings.get('from_alias'),
            recipient_list=[useremail], html_message=msg
        )

    # Public :
    def send_verification_link(self, request, form=None):
        
        if form:
            inactive_user = form.save(commit=False)
        
        inactive_user.is_active = False
        inactive_user.save()

...

```