### PR TITLE
Set default auto field

### DIFF
--- a/verify_email/apps.py
+++ b/verify_email/apps.py
@@ -7,6 +7,7 @@ logger = logging.getLogger(__name__)
 
 class VerifyEmailConfig(AppConfig):
     name = 'verify_email'
+    default_auto_field = 'django.db.models.BigAutoField'
 
     def ready(self):
         logger.info('[Email Verification] : importing signals    - OK.')


### PR DESCRIPTION
In order to avoid a database migration, we set default_auto_field to 'django.db.models.BigAutoField' for the VerifyEmail app. This is required, since Django defaults to django.db.models.AutoField since Django 3.2 (https://docs.djangoproject.com/en/3.2/ref/settings/#std-setting-DEFAULT_AUTO_FIELD).

By setting default_auto_field to the big auto field, the VerifyEmail app sticks with the existing big auto field in the database.