### PR TITLE
Add helper script to allow running Django management commands easily

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+import sys
+sys.path.append('..')
+
+from django.conf import settings
+settings.configure(INSTALLED_APPS=['django.contrib.auth', 'django.contrib.contenttypes', 'verify_email'])
+
+import django
+django.setup()
+
+from django.core.management import execute_from_command_line
+execute_from_command_line(sys.argv)


### PR DESCRIPTION
Add a helper script to be able to run Django management commands without a surrounding Django project.