### PR TITLE
Fix method invocation of send_verification_link

### DIFF
--- a/verify_email/email_handler.py
+++ b/verify_email/email_handler.py
@@ -95,7 +95,7 @@ class _VerifyEmail:
 
 #  These is supposed to be called outside of this module
 def send_verification_email(request, form):
-    return _VerifyEmail().send_verification_link(request, form)
+    return _VerifyEmail().send_verification_link(request, form=form)
 
 
 #  These is supposed to be called outside of this module


### PR DESCRIPTION
The signature of send_verification_link was changed in a960b57be3cf9ef519e49f48b38f21545816f72f. However, the corresponding invocation of this method in the documented public API was left unchanged, which introduced a bug reported in https://github.com/foo290/Django-Verify-Email/issues/68.