### PR TITLE
Email subject template instead of hardcoded string

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ The app is packed with default HTML templates to handle the web pages but if you
 ```
 HTML_MESSAGE_TEMPLATE = "path/to/html_template.html"
 
+EMAIL_VERIFICATION_SUBJECT_TEMPLATE = "path/to/subject.txt"
+
 VERIFICATION_SUCCESS_TEMPLATE = "path/to/success.html"
 
 VERIFICATION_FAILED_TEMPLATE = "path/to/failed.html"
@@ -298,11 +300,6 @@ REQUEST_NEW_EMAIL_TEMPLATE = "path/to/email.html"
 LINK_EXPIRED_TEMPLATE = 'path/to/expired.html'
 
 NEW_EMAIL_SENT_TEMPLATE  = 'path/to/new_email_sent.html'
-```
-```
-SUBJECT = 'subject of email'
-
-# default subject is: Email Verification Mail
 ```
 </p>
 

--- a/verify_email/app_configurations.py
+++ b/verify_email/app_configurations.py
@@ -25,9 +25,9 @@ class GetFieldFromSettings:
                 False
             ),
 
-            'subject': (
-                "SUBJECT",
-                "Email Verification Mail"
+            'email_verification_subject_template': (
+                "EMAIL_VERIFICATION_SUBJECT_TEMPLATE",
+                "verify_email/email_verification_subject.txt"
             ),
 
             'email_field_name': (

--- a/verify_email/locale/de/LC_MESSAGES/django.po
+++ b/verify_email/locale/de/LC_MESSAGES/django.po
@@ -1,0 +1,24 @@
+# Django-Verify-Email
+# Copyright (C) 2023 Django-Verify-Email contributors
+# This file is distributed under the same license as the PACKAGE package.
+# Sebastian Haas, 2023
+# SECOND AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-11-06 14:25+0100\n"
+"PO-Revision-Date: 2023-11-06 14:27+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4.1\n"
+
+#: templates/verify_email/email_verification_subject.txt:3
+msgid "Confirm Your Email Address"
+msgstr "E-Mail-Adresse bestätigen"

--- a/verify_email/templates/verify_email/email_verification_subject.txt
+++ b/verify_email/templates/verify_email/email_verification_subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktranslate %}Confirm Your Email Address{% endblocktranslate %}
+{% endautoescape %}


### PR DESCRIPTION
Instead of a direct setting, the email subject can now be set using a template.

This is heavily inspired and pretty much copied from the way Django is rendering the email subject for its password reset links.

See https://github.com/django/django/blob/main/django/contrib/auth/templates/registration/password_reset_subject.txt
See https://docs.djangoproject.com/en/4.2/topics/auth/default/#django.contrib.auth.views.PasswordResetView.subject_template_name

This approach also allows for a i18n email subject, which is not really possible otherwise (gettext translations in settings will likely break email services).