### PR TITLE
Explicitly set default auto field

### DIFF
--- a/verify_email/apps.py
+++ b/verify_email/apps.py
@@ -7,6 +7,7 @@ logger = logging.getLogger(__name__)
 
 class VerifyEmailConfig(AppConfig):
     name = 'verify_email'
+    default_auto_field = "django.db.models.BigAutoField"
 
     def ready(self):
         logger.info('[Email Verification] : importing signals    - OK.')


### PR DESCRIPTION
Leaving this unset was making it incompatible with any project that had set the DEFAULT_AUTO_FIELD django setting to anything else